### PR TITLE
修改了右键菜单的逻辑

### DIFF
--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import type customContextMenu from './customContextMenu.type'
 import { clipboard } from 'electron'
-import { computed, onMounted, reactive, ref, useTemplateRef, watchEffect } from 'vue'
+import { computed, onMounted, onBeforeUnmount, reactive, ref, useTemplateRef, watchEffect } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 interface Props {
@@ -81,6 +81,14 @@ onMounted(() => {
     position.left = 'auto'
     position.right = '10px'
   }
+
+  const mouseEventHandler = (e: PointerEvent) => {
+    if (!useCateDom.value!.contains(e.target as Node)) {
+      emits('closeContext')
+    }
+  }
+  document.addEventListener('pointerdown', mouseEventHandler)
+  onBeforeUnmount(() => document.removeEventListener('pointerdown', mouseEventHandler))
 })
 
 const showItemChild = ref(false)


### PR DESCRIPTION
本PR旨在改变右键点击多个TODO条目时，右键菜单会重叠导致视觉上的混乱的情况。

原逻辑：右键点击一个TODO条目时，会产生该TODO条目的右键菜单，**仅在再次点击该TODO条目时**，右键菜单关闭。右键点击多个TODO条目时，会有很多右键菜单重叠到一起，容易混乱。
新逻辑：右键点击一个TODO条目时，会产生该TODO条目的右键菜单，**当点击该右键菜单以外的任何位置时**，右键菜单关闭。